### PR TITLE
Inflictor fix

### DIFF
--- a/gamemodes/terrortown/entities/entities/ttt_melonmine.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_melonmine.lua
@@ -171,7 +171,7 @@ if SERVER then
         local dmgOwner = self:GetOriginator()
         dmgOwner = IsValid(dmgOwner) and dmgOwner or self
 
-        local r_inner = 240
+        local r_inner = 200
         local r_outer = 240
 
         -- damage through walls

--- a/gamemodes/terrortown/entities/entities/ttt_melonmine.lua
+++ b/gamemodes/terrortown/entities/entities/ttt_melonmine.lua
@@ -171,7 +171,11 @@ if SERVER then
         local dmgOwner = self:GetOriginator()
         dmgOwner = IsValid(dmgOwner) and dmgOwner or self
 
+        local r_inner = 240
         local r_outer = 240
+
+        -- damage through walls
+        self:SphereDamage(dmgOwner, pos, r_inner)
 
         -- explosion damage
         util.BlastDamage(self, dmgOwner, pos, r_outer, self:GetDmg())
@@ -264,7 +268,7 @@ function ENT:SphereDamage(dmgOwner, center, radius)
             local dmginfo = DamageInfo()
             dmginfo:SetDamage(dmg)
             dmginfo:SetAttacker(dmgOwner)
-            dmginfo:SetInflictor(self)
+            dmginfo:SetInflictor(ents.Create("weapon_ttt_melonmine"))
             dmginfo:SetDamageType(DMG_BLAST)
             dmginfo:SetDamageForce(center - ply:GetPos())
             dmginfo:SetDamagePosition(ply:GetPos())


### PR DESCRIPTION
This fixed two issues.

The first one is that the SphereDamage function wasn't being used.
Now if a player is behind a wall he will also get damage through the explosion.

The second one was that the melon mine was not shown as the inflictor in the body search window.
Now the melon mine is correctly shown.

You can edit the value of r_inner if you think it is too high/low.